### PR TITLE
Fix spillover bugs

### DIFF
--- a/R/spillover.R
+++ b/R/spillover.R
@@ -211,9 +211,10 @@ setMethod("spillover",
                 channel_order <- channel_order - (channel_order > unstained)
               }
               
-              # Then reverse any shuffling so the rows are in the same
-              # order as the channels for symmetry
-              inten <- inten[order(channel_order),]
+              # Place the rows (which originally corresponded to samples) in
+              # channel_order, which is the order that rows should be placed
+              # in in order to have the same order as the channels
+              inten <- inten[channel_order,]
               
               rownames(inten) <- colnames(inten)
               inten

--- a/R/spillover.R
+++ b/R/spillover.R
@@ -142,9 +142,9 @@ setMethod("spillover",
                 if (is.na(match(ssc, allcols))) {
                   stop("Could not find side scatter parameter. ",
                        "Please set the ssc parameter", call. = FALSE)
-                  n2f <- norm2Filter(fsc, ssc, scale.factor = 1.5)
-                  x <- Subset(x, n2f)
                 }
+                n2f <- norm2Filter(fsc, ssc, scale.factor = 1.5)
+                x <- Subset(x, n2f)
               }
               
               # Here, we match the stain channels with the compensation controls

--- a/tests/testthat/test-spillover.R
+++ b/tests/testthat/test-spillover.R
@@ -17,7 +17,9 @@ controls <- controls[,c(3,1,4,5,2,6,7)]
 test_that("spillover: Match columns using regexpr", {
   ref_file <- system.file("extdata", "compdata", "compref1", package="flowCore")
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
-  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H", ssc="SSC-H", patt = "-H", stain_match="regexpr")
+  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H",
+                    ssc="SSC-H", patt = "-H", stain_match="regexpr",
+                    useNormFilt = FALSE)
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -28,7 +30,9 @@ test_that("spillover: Match columns using ordered", {
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
   # The spillover matrix here should (appropriately) be incorrect bc the rows are
   # not in the order of the columns.
-  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H", ssc="SSC-H", patt = "-H", stain_match="ordered")
+  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H",
+                    ssc="SSC-H", patt = "-H", stain_match="ordered",
+                    useNormFilt = FALSE)
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -37,19 +41,20 @@ test_that("spillover: Match columns using ordered", {
 test_that("spillover: Match columns using intensity", {
   ref_file <- system.file("extdata", "compdata", "compref1", package="flowCore")
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
-  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H", ssc="SSC-H", patt = "-H", stain_match="intensity")
+  comp <- spillover(controls, unstained = "UNSTAINED", fsc="FSC-H",
+                    ssc="SSC-H", patt = "-H", stain_match="intensity",
+                    useNormFilt = FALSE)
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
 })
-
 
 test_that("spillover_match: Using path to dir with files", {
   ref_file <- system.file("extdata", "compdata", "compref3", package="flowCore")
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
   matched <- spillover_match(path=control_path, fsc="FSC-H", ssc="SSC-H", matchfile = matchfile_path)
   comp <- spillover(matched, prematched = TRUE, fsc="FSC-H", ssc="SSC-H", patt = "-H",
-                    useNormFilt = TRUE, method = "mode")
+                    useNormFilt = FALSE, method = "mode")
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -61,7 +66,7 @@ test_that("spillover_match: Using preconstructed flowSet with filenames as sampl
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
   matched <- spillover_match(controls, fsc="FSC-H", ssc="SSC-H", matchfile = matchfile_path)
   comp <- spillover(matched, prematched = TRUE, fsc="FSC-H", ssc="SSC-H", patt = "-H",
-                    useNormFilt = TRUE, method = "mode")
+                    useNormFilt = FALSE, method = "mode")
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -71,7 +76,8 @@ test_that("spillover_ng: Using path to dir with files", {
   ref_file <- system.file("extdata", "compdata", "compref4", package="flowCore")
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
   comp <- spillover_ng(path=control_path, fsc="FSC-H", ssc="SSC-H", 
-                       patt="-H", matchfile = matchfile_path, pregate = FALSE)
+                       patt="-H", matchfile = matchfile_path, pregate = FALSE,
+                       useNormFilt = FALSE)
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -83,7 +89,8 @@ test_that("spillover_ng: Using preconstructed flowSet with filenames as sample n
   comp_ref <- as.matrix(read.table(ref_file, check.names = FALSE))
   matched <- spillover_match(controls, fsc="FSC-H", ssc="SSC-H", matchfile = matchfile_path)
   comp <- spillover_ng(path=control_path, fsc="FSC-H", ssc="SSC-H", 
-                       patt="-H", matchfile = matchfile_path, pregate = FALSE)
+                       patt="-H", matchfile = matchfile_path, pregate = FALSE,
+                       useNormFilt = FALSE)
   expect_equal(colnames(comp), colnames(comp_ref))
   expect_equal(rownames(comp), rownames(comp_ref))
   expect_equivalent(comp, comp_ref, tolerance=3e-08)
@@ -104,7 +111,8 @@ test_that("spillover_ng: Using preconstructed flowSet with channels in new order
   # approach used to re-order rows of the matrix in the spillover function.
   
   comp <- spillover_ng(x=fs, fsc="FSC-H", ssc="SSC-H", 
-                       patt="-H", matchfile = matchfile_path, pregate = FALSE)
+                       patt="-H", matchfile = matchfile_path, pregate = FALSE,
+                       useNormFilt = FALSE)
   # The diagonals should be equal to 1
   for (i in 1:4) {
     expect_equal(comp[i,i], 1)


### PR DESCRIPTION
This PR fixes #39 and #41 

For #41 (issue in spillover_ng : rows are swapped), the problem was that the rows of the returned compensation matrix were being ordered an extra time. This was not caught by the existing tests because those tests have the property that `channel_order == order(channel_order)`. The helpful example provided in #41 does not have this property. 

`inten <- inten[order(channel_order),]` is now simply `inten <- inten[channel_order,]`