### PR TITLE
Add error message for spillover control overmatch

### DIFF
--- a/R/spillover.R
+++ b/R/spillover.R
@@ -166,6 +166,10 @@ setMethod("spillover",
                 } else {
                   channel_order <- sapply(cols, grep, x = sampleNames(x), fixed = TRUE)
                 }
+                if (any(sapply(channel_order, length) > 1)){
+                  stop("Multiple compensation-control names match to a common stain",
+                       call. = FALSE)
+                }
                 # Clip out those channels that do not match to a name
                 matched <- channel_order[sapply(channel_order, length) != 0]
                 if (anyDuplicated(matched)) {


### PR DESCRIPTION
This just adds a more helpful error message for the case in #44, where the regex matches multiple files. The regex check does not include ^ or $ anchors (possibly appropriately), so in the relatively common case of a channel being a substring of another channel (e.g. "V610" and "UV610"), the match will be ambiguous and the return from `grep` will be a jagged list instead of a vector.