### PR TITLE
Update landmark registration call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          error-on: '"error"'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ Lazyload: yes
 URL: http://www.github.com/RGLab/flowStats
 BugReports: http://www.github.com/RGLab/flowStats/issues
 biocViews: ImmunoOncology, FlowCytometry, CellBasedAssays
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowStats
 Type: Package
 Title: Statistical methods for the analysis of flow cytometry data
-Version: 4.9.1
+Version: 4.9.2
 Author: Florian Hahne, Nishant Gopalakrishnan, Alireza Hadj Khodabakhshi,
         Chao-Jen Wong, Kyongryun Lee
 Maintainer: Greg Finak <greg@ozette.com>, Mike Jiang <mike@ozette.com>

--- a/R/warpSet.R
+++ b/R/warpSet.R
@@ -16,8 +16,6 @@
 #' a warning is issued in case the latter is bigger than the former,
 #' indicating the likely removal of signal by the normalization
 #' procedure.
-#' @param monwrd Logical. Compute strictly monotone warping
-#' functions. This gets directly passed on to
 #' \code{\link[fda]{landmarkreg}}.
 #' @param subsample Numeric. Reduce the number of events in each \code{flowSet}
 #' by sub sampling for all density estimation steps and the calculation
@@ -80,7 +78,7 @@
 #' dat <- transform(ITN, "CD4"=asinh(CD4), "CD3"=asinh(CD3), "CD8"=asinh(CD8))
 #' lg <- lymphGate(dat, channels=c("CD3", "SSC"), preselection="CD4",scale=1.5)
 #' dat <- Subset(dat, lg)
-#' datr <- warpSet(dat, "CD8", grouping="GroupID", monwrd=TRUE)
+#' datr <- warpSet(dat, "CD8", grouping="GroupID")
 #' if(require(flowViz)){
 #'   d1 <- densityplot(~CD8, dat, main="original", filter=curv1Filter("CD8"))
 #'   d2 <- densityplot(~CD8, datr, main="normalized", filter=curv1Filter("CD8"))
@@ -106,7 +104,7 @@ warpSet.GatingSet <- function(x,node=NULL, ...){
 	  warpSet(x = data,...)
 }
 #' @rdname warpSet
-warpSet.cytoset <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NULL,
+warpSet.cytoset <- function(x, stains, grouping=NULL,  subsample=NULL,
                                 peakNr=NULL, clipRange=0.01, nbreaks=11, fres, bwFac=2,
                                 warpFuns=FALSE,target=NULL,chunksize=10,
                                 ...)
@@ -133,7 +131,7 @@ warpSet.cytoset <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NUL
     #Does Subset clobber anything in a permanent way for an ncdfFlowSet? Check this, otherwise use subsample.
     x <- Subset(x, sampleFilter(size=subsample))
   }
-  flowCore:::checkClass(monwrd, "logical", 1)
+  
   flowCore:::checkClass(bwFac, "numeric", 1)
   
   ## find landmarks
@@ -253,9 +251,9 @@ warpSet.cytoset <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NUL
       }
     }else{ ## multiple peaks: warping
       if(is.null(target)){
-        capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, monwrd=monwrd,...))  
+        capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar,...))  
       }else{
-        capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, monwrd=monwrd,...)) 
+        capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, ...)) 
       }
       warpfdobj <- regDens$warpfd
       warpedX <- eval.fd(warpfdobj, argvals)
@@ -353,7 +351,7 @@ warpSet.cytoset <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NUL
 
 # When isNew == FALSE, the original cdf is modified 
 # when isNew == TRUE, a new cdf is created
-warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NULL,
+warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, subsample=NULL,
 		peakNr=NULL, clipRange=0.01, nbreaks=11, fres, bwFac=2,
 		warpFuns=FALSE,target=NULL,chunksize=10,isNew=FALSE,newNcFile=NULL,
 		...)
@@ -386,7 +384,7 @@ warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample
 		#Does Subset clobber anything in a permanent way for an ncdfFlowSet? Check this, otherwise use subsample.
 		x <- Subset(x, sampleFilter(size=subsample))
 	}
-	flowCore:::checkClass(monwrd, "logical", 1)
+	
 	flowCore:::checkClass(bwFac, "numeric", 1)
 	
 	## find landmarks
@@ -506,9 +504,9 @@ warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample
 			}
 		}else{ ## multiple peaks: warping
 			if(is.null(target)){
-				capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, monwrd=monwrd,...))  
+				capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, ...))  
 			}else{
-				capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, monwrd=monwrd,...)) 
+				capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, ...)) 
 			}
 			warpfdobj <- regDens$warpfd
 			warpedX <- eval.fd(warpfdobj, argvals)
@@ -609,7 +607,7 @@ warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample
 	expData
 }
 #
-warpSet.flowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NULL,
+warpSet.flowSet <- function(x, stains, grouping=NULL,  subsample=NULL,
 		peakNr=NULL, clipRange=0.01, nbreaks=11, fres, bwFac=2,
 		warpFuns=FALSE,target=NULL,
 		...)
@@ -635,7 +633,7 @@ warpSet.flowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NUL
 			if(!grouping %in% names(pData(x)))
 				stop("'", grouping, "' is not a phenoData variable.")
 	}
-	flowCore:::checkClass(monwrd, "logical", 1)
+	
 	flowCore:::checkClass(bwFac, "numeric", 1)
 	
 	## find landmarks
@@ -762,12 +760,12 @@ warpSet.flowSet <- function(x, stains, grouping=NULL, monwrd=TRUE, subsample=NUL
 		}else{ ## multiple peaks: warping
 			if(is.null(target)){
 				capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, 
-								monwrd=monwrd, ...))  
+								 ...))  
 			}else{
 				
 				#add a small amount of noise 1% of sd (robust) to the target landmarks
 				capture.output(regDens <- landmarkreg(fdobj, landmarks, x0marks=apply(landmarks,2,jitter)[rownames(landmarks)%in%target,],WfdPar=WfdPar, 
-								monwrd=monwrd, ...))
+								 ...))
 			}
 			warpfdobj <- regDens$warpfd
 			warpedX <- eval.fd(warpfdobj, argvals)

--- a/R/warpSet.R
+++ b/R/warpSet.R
@@ -251,7 +251,7 @@ warpSet.cytoset <- function(x, stains, grouping=NULL,  subsample=NULL,
       }
     }else{ ## multiple peaks: warping
       if(is.null(target)){
-        capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar,...))  
+        capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,mean), WfdPar=WfdPar,...))  
       }else{
         capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, ...)) 
       }
@@ -504,7 +504,7 @@ warpSet.ncdfFlowSet <- function(x, stains, grouping=NULL, subsample=NULL,
 			}
 		}else{ ## multiple peaks: warping
 			if(is.null(target)){
-				capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, ...))  
+				capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,mean), WfdPar=WfdPar, ...))  
 			}else{
 				capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,jitter)[rownames(landmarks)%in%target,], WfdPar=WfdPar, ...)) 
 			}
@@ -759,7 +759,7 @@ warpSet.flowSet <- function(x, stains, grouping=NULL,  subsample=NULL,
 			}
 		}else{ ## multiple peaks: warping
 			if(is.null(target)){
-				capture.output(regDens <- landmarkreg(fdobj, landmarks, WfdPar=WfdPar, 
+				capture.output(regDens <- landmarkreg(fdobj, landmarks,x0marks= apply(landmarks,2,mean), WfdPar=WfdPar, 
 								 ...))  
 			}else{
 				

--- a/man/warpSet.Rd
+++ b/man/warpSet.Rd
@@ -14,7 +14,6 @@ warpSet(x, ...)
   x,
   stains,
   grouping = NULL,
-  monwrd = TRUE,
   subsample = NULL,
   peakNr = NULL,
   clipRange = 0.01,
@@ -41,10 +40,7 @@ variables in the \code{phenoData} slot of \code{x} used as a grouping
 factor. The within-group and between-group variance is computed and
 a warning is issued in case the latter is bigger than the former,
 indicating the likely removal of signal by the normalization
-procedure.}
-
-\item{monwrd}{Logical. Compute strictly monotone warping
-functions. This gets directly passed on to
+procedure.
 \code{\link[fda]{landmarkreg}}.}
 
 \item{subsample}{Numeric. Reduce the number of events in each \code{flowSet}
@@ -113,7 +109,7 @@ data(ITN)
 dat <- transform(ITN, "CD4"=asinh(CD4), "CD3"=asinh(CD3), "CD8"=asinh(CD8))
 lg <- lymphGate(dat, channels=c("CD3", "SSC"), preselection="CD4",scale=1.5)
 dat <- Subset(dat, lg)
-datr <- warpSet(dat, "CD8", grouping="GroupID", monwrd=TRUE)
+datr <- warpSet(dat, "CD8", grouping="GroupID")
 if(require(flowViz)){
   d1 <- densityplot(~CD8, dat, main="original", filter=curv1Filter("CD8"))
   d2 <- densityplot(~CD8, datr, main="normalized", filter=curv1Filter("CD8"))


### PR DESCRIPTION
The latest `fda::landmarkreg` api change [breaks](https://github.com/RGLab/flowStats/runs/7163532051?check_suite_focus=true#step:8:66) `flowStat::warpSet` function, therefore failed bioconductor package build
- `monwrd` argument (used to switch on and off the monotonic smoothing flag) is no longer supported, now it has to be strictly monotonic by default (https://cran.r-project.org/web/packages/fda/news.html)
- `x0marks` argument is no longer optional, it is supposed to be a vector of times of landmarks for target curve. Now I manually set it to the mean of the landmark times in ximarks (the input data) based on the recommendation of doc

Test shows normalization behaves as expected
![image](https://user-images.githubusercontent.com/1385649/177233082-1089da45-a389-44ad-8a3c-b77f89aaaf19.png)
```r
gs <- normalize(gs, populations=c("CD4+CD8-CD69"),dims=c("CD69"), minCountThreshold = 50)
Estimating landmarks for channel CD69 ...
Registering curves for parameter CD69 
```
![image](https://user-images.githubusercontent.com/1385649/177233230-55f0d675-d9e2-4b74-a013-75867a9b0d85.png)
